### PR TITLE
Parallel fetch without relying on Gitlab headers

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/Pager.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/Pager.java
@@ -394,7 +394,7 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
         while (!allPagesFetched) {
             List<Callable<List<T>>> tasks = new ArrayList<>();
 
-            while(tasks.size() < 100) {
+            while (tasks.size() < 100) {
                 final int pageNumber = taskNr++;
                 tasks.add(() -> page(pageNumber));
             }

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/Pager.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/Pager.java
@@ -300,7 +300,7 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
             currentPage = 1;
         }
 
-        if (pageNumber > totalPages && pageNumber > kaminariNextPage) {
+        if (pageNumber > totalPages && pageNumber > kaminariNextPage && !api.gitLabApi.isDefaultPageFetchParallel()) {
             throw new NoSuchElementException();
         } else if (pageNumber < 1) {
             throw new NoSuchElementException();
@@ -388,22 +388,34 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
             throw new IllegalStateException("no parallel task executor set, cannot fetch pages in parallel");
         }
 
-        List<Callable<List<T>>> tasks = new ArrayList<>();
-        for (int i = 1; i <= totalPages; i++) {
-            final int pageNumber = i;
-            tasks.add(() -> page(pageNumber));
-        }
-        try {
-            List<List<T>> results = taskExecutor.execute(tasks);
-            for (List<T> items : results) {
-                allItems.addAll(items);
+        int taskNr = 1;
+        boolean allPagesFetched = false;
+
+        while (!allPagesFetched) {
+            List<Callable<List<T>>> tasks = new ArrayList<>();
+
+            while(tasks.size() < 100) {
+                final int pageNumber = taskNr++;
+                tasks.add(() -> page(pageNumber));
             }
-            return allItems;
-        } catch (GitLabApiException ge) {
-            throw ge;
-        } catch (Exception e) {
-            throw new GitLabApiException(e);
+            try {
+                List<List<T>> results = taskExecutor.execute(tasks);
+                for (List<T> items : results) {
+                    if (items.isEmpty()) {
+                        allPagesFetched = true;
+                        break;
+                    } else {
+                        allItems.addAll(items);
+                    }
+                }
+            } catch (GitLabApiException ge) {
+                throw ge;
+            } catch (Exception e) {
+                throw new GitLabApiException(e);
+            }
         }
+
+        return allItems;
     }
 
     private List<T> fetchAllSynchronously() {

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/Pager.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/Pager.java
@@ -388,13 +388,18 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
             throw new IllegalStateException("no parallel task executor set, cannot fetch pages in parallel");
         }
 
+        int maxTasks = taskExecutor.getParallelCount();
+        if (totalPages != -1) {
+            maxTasks = Math.min(totalPages, taskExecutor.getParallelCount());
+        }
+
         int taskNr = 1;
         boolean allPagesFetched = false;
 
         while (!allPagesFetched) {
-            List<Callable<List<T>>> tasks = new ArrayList<>();
+            List<Callable<List<T>>> tasks = new ArrayList<>(maxTasks);
 
-            while (tasks.size() < 100) {
+            while (tasks.size() < maxTasks) {
                 final int pageNumber = taskNr++;
                 tasks.add(() -> page(pageNumber));
             }
@@ -403,9 +408,9 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
                 for (List<T> items : results) {
                     if (items.isEmpty()) {
                         allPagesFetched = true;
-                        break;
                     } else {
                         allItems.addAll(items);
+                        allPagesFetched = items.size() < itemsPerPage;
                     }
                 }
             } catch (GitLabApiException ge) {

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ParallelTaskExecutor.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ParallelTaskExecutor.java
@@ -5,4 +5,6 @@ import java.util.concurrent.Callable;
 
 public interface ParallelTaskExecutor {
     public <T> List<T> execute(List<Callable<T>> tasks) throws Exception;
+
+    public int getParallelCount();
 }


### PR DESCRIPTION
When the number of resources to fetch is >10k, Gitlab does not send the `X-Total` and `X-Total-Page` headers in the API response. For this reason, the parallel fetch implementation should not rely on those.

Instead, it should try to fetch different pages in parallel until they come up empty, meaning that there is nothing else to fetch.